### PR TITLE
29 updated couchdb and debian 7 which is now archived

### DIFF
--- a/composed/Dockerfile
+++ b/composed/Dockerfile
@@ -2,6 +2,12 @@ FROM ubuntu:xenial
 
 MAINTAINER Ephraim Muhia (emuhia@ona.io)
 
+# RUN echo "deb [check-valid-until=no] http://cdn-fastly.deb.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN touch /etc/apt/sources.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+RUN echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks
+RUN apt-get -o Acquire::Check-Valid-Until=false update
 
 # Installing supervisord
 RUN apt-get update && apt-get install -y supervisor

--- a/composed/Migration_Dockerfile
+++ b/composed/Migration_Dockerfile
@@ -2,6 +2,13 @@ FROM java:openjdk-8u111-jdk
 
 MAINTAINER Samuel Githengi (sgithengi@ona.io)
 
+# RUN echo "deb [check-valid-until=no] http://cdn-fastly.deb.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN touch /etc/apt/sources.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+RUN echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/100disablechecks
+RUN apt-get -o Acquire::Check-Valid-Until=false update
+
 #Install database clients ,netcat and maven
 RUN apt-get update && \
 apt-get install -y netcat && \

--- a/composed/docker-compose.yml
+++ b/composed/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_OPENMRS_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_OPENMRS_DATABASE}
   couchdb:
-    image: "klaemo/couchdb:1.6.1"
+    image: "couchdb:2.3.0"
     volumes:
       - opensrp_couchdb:/usr/local/var/lib/couchdb
     environment:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
   couchdb:
-    image: "klaemo/couchdb:1.6.1"
+    image: "couchdb:2.3.0"
     volumes:
       - opensrp_couchdb:/usr/local/var/lib/couchdb
     environment:


### PR DESCRIPTION
klaemo/couchdb is outdated. See [here](https://hub.docker.com/r/klaemo/couchdb/)

Debian 8 has been archived. See [here](https://wiki.debian.org/DebianJessie)